### PR TITLE
レスポンスヘッダーのContent-Typeをapplication/jsonにするためControllerの戻り値をMap変更。DELETEをステータスコード204で返す。

### DIFF
--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -21,7 +21,7 @@ public class NameController {
     public List<String> getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
 
-        return List.of("名前:" + name, "生年月日:" + date);
+        return List.of("name:" + name, "dateOfBirth:" + date);
     }
 
     @PostMapping("/name")

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 
 import static org.springframework.http.ResponseEntity.created;
@@ -18,10 +17,9 @@ import static org.springframework.http.ResponseEntity.created;
 public class NameController {
 
     @GetMapping("/name")
-    public List<String> getName(
+    public NameDateFormat getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
-
-        return List.of("name:" + name, "dateOfBirth:" + date);
+        return new NameDateFormat("tatsuya", "1993-10-30");
     }
 
     @PostMapping("/name")

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -9,9 +9,13 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.Map;
+
+import static org.springframework.http.ResponseEntity.created;
 
 @RestController
 public class NameController {
+
     @GetMapping("/name")
     String getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
@@ -20,24 +24,23 @@ public class NameController {
     }
 
     @PostMapping("/name")
-    public ResponseEntity<String> create(@RequestBody NameDateFormat form) {
+    ResponseEntity<Map<String, String>> create(@RequestBody NameDateFormat form) {
         // 登録処理は省略
         URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
                 .path("/name")
                 .build()
                 .toUri();
-        return ResponseEntity.created(url).body("name,date, successfully created");
+        return created(url).body(Map.of("name", "successfully created"));
     }
 
     @PatchMapping("/name/{number}")
-    public String update(@PathVariable("number") int number, @RequestBody UpdateForm form) {
+    ResponseEntity<Map<String, String>> update(@PathVariable("number") int number, @RequestBody UpdateForm form) {
         //　更新処理は省略
-        return ( "message, successfully updated" );
+        return ResponseEntity.ok(Map.of("message", "successfully updated"));
     }
 
     @DeleteMapping("/name/{number}")
-    public String deleteName(@PathVariable("number") int number) {
-        // 更新処理は省略
-        return ( "message,name successfully deleted" );
+    public ResponseEntity<Void> delete(@PathVariable("number") int deleteNumber) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -11,25 +11,23 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.Map;
 
-import static org.springframework.http.ResponseEntity.created;
-
 @RestController
 public class NameController {
 
     @GetMapping("/name")
-    public NameDateFormat getName(
+    public NameDateResponse getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
-        return new NameDateFormat("tatsuya", "1993-10-30");
+        return new NameDateResponse("tatsuya", "1993-10-30");
     }
 
     @PostMapping("/name")
-    ResponseEntity<Map<String, String>> create(@RequestBody NameDateFormat form) {
+    ResponseEntity<Map<String, String>> create(@RequestBody NameDateResponse form) {
         // 登録処理は省略
         URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
                 .path("/name")
                 .build()
                 .toUri();
-        return created(url).body(Map.of("name,date", "successfully created"));
+        return ResponseEntity.created(url).body(Map.of("message", "name and date was successfully created"));
     }
 
     @PatchMapping("/name/{number}")

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.http.ResponseEntity.created;
@@ -17,10 +18,10 @@ import static org.springframework.http.ResponseEntity.created;
 public class NameController {
 
     @GetMapping("/name")
-    String getName(
+    public List<String> getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
 
-        return "名前:" + name + System.lineSeparator() + "生年月日:" + date;
+        return List.of("名前:" + name + System.lineSeparator() + "生年月日:" + date);
     }
 
     @PostMapping("/name")

--- a/src/main/java/com/example/restapi/NameController.java
+++ b/src/main/java/com/example/restapi/NameController.java
@@ -21,7 +21,7 @@ public class NameController {
     public List<String> getName(
             @Validated @NotNull @NotBlank @Length(max = 20) @RequestParam("name") String name, @RequestParam("date") String date) {
 
-        return List.of("名前:" + name + System.lineSeparator() + "生年月日:" + date);
+        return List.of("名前:" + name, "生年月日:" + date);
     }
 
     @PostMapping("/name")
@@ -31,7 +31,7 @@ public class NameController {
                 .path("/name")
                 .build()
                 .toUri();
-        return created(url).body(Map.of("name", "successfully created"));
+        return created(url).body(Map.of("name,date", "successfully created"));
     }
 
     @PatchMapping("/name/{number}")

--- a/src/main/java/com/example/restapi/NameDateFormat.java
+++ b/src/main/java/com/example/restapi/NameDateFormat.java
@@ -1,16 +1,30 @@
 package com.example.restapi;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
 public class NameDateFormat {
     private String date;
     private String name;
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
 
     public NameDateFormat(String name, String date) {
         this.name = name;
         this.date = date;
     }
+
+
 }

--- a/src/main/java/com/example/restapi/NameDateFormat.java
+++ b/src/main/java/com/example/restapi/NameDateFormat.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class NameDateFormat {
     private int date;
     private String name;
+
 }

--- a/src/main/java/com/example/restapi/NameDateFormat.java
+++ b/src/main/java/com/example/restapi/NameDateFormat.java
@@ -6,7 +6,11 @@ import lombok.Setter;
 @Getter
 @Setter
 public class NameDateFormat {
-    private int date;
+    private String date;
     private String name;
 
+    public NameDateFormat(String name, String date) {
+        this.name = name;
+        this.date = date;
+    }
 }

--- a/src/main/java/com/example/restapi/NameDateResponse.java
+++ b/src/main/java/com/example/restapi/NameDateResponse.java
@@ -1,6 +1,6 @@
 package com.example.restapi;
 
-public class NameDateFormat {
+public class NameDateResponse {
     private String date;
     private String name;
 
@@ -21,7 +21,7 @@ public class NameDateFormat {
     }
 
 
-    public NameDateFormat(String name, String date) {
+    public NameDateResponse(String name, String date) {
         this.name = name;
         this.date = date;
     }

--- a/src/main/java/com/example/restapi/RestapiApplication.java
+++ b/src/main/java/com/example/restapi/RestapiApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class RestapiApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(RestapiApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(RestapiApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/example/restapi/UpdateForm.java
+++ b/src/main/java/com/example/restapi/UpdateForm.java
@@ -1,10 +1,14 @@
 package com.example.restapi;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
 public class UpdateForm {
     private String name;
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 }


### PR DESCRIPTION
# 課題7の概要

## HTTPメソッドのGET/POST/PATCH/DELETEのリクエストを扱えるControllerを実装。

- http://localhost:8080/names?name=koyama のようにクエリ文字列を受け取れるようにする。
- 名前以外にも生年月日を受け取れるよう実装する。
- バリデーションについて調べてnameが空文字、null、20文字以上の場合はエラーとする。

### GET　HTTPステータスコードの期待値200
<img width="1470" alt="スクリーンショット 2023-06-20 12 37 20" src="https://github.com/tatsuya-d/Kadai7/assets/133928911/f5d6eecf-ecc7-4892-839f-0d1706321e68">

### POSTHTTPステータスコードの期待値201
<img width="1470" alt="スクリーンショット 2023-06-20 12 47 37" src="https://github.com/tatsuya-d/Kadai7/assets/133928911/d0ad7e82-0475-4882-bc03-743999940709">

### PATCHステータスコードの期待値200
<img width="1470" alt="スクリーンショット 2023-06-20 12 57 00" src="https://github.com/tatsuya-d/Kadai7/assets/133928911/f117a185-f769-4adb-a9ca-fb5f8d458b35">

### DELIETE PATCHステータスコードの期待値204
<img width="1470" alt="スクリーンショット 2023-06-20 15 16 50" src="https://github.com/tatsuya-d/Kadai7/assets/133928911/5bd0f524-1d7c-4c7d-836b-fc8fc06d6d49">

## レスポンスヘッダーのContent-Type
<img width="1470" alt="スクリーンショット 2023-06-20 15 16 23" src="https://github.com/tatsuya-d/Kadai7/assets/133928911/98a9f0d9-6d1a-40a1-8b3b-1d08abb3f3eb">



